### PR TITLE
Add option to save cookies with Cheerio scraper

### DIFF
--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -68,7 +68,7 @@
             "default": false
         },
         "useCookieJar": {
-            "title": "Use cookie jar",
+            "title": "Save cookies",
             "type": "boolean",
             "description": "Crawler will use a cookie jar to persist cookies between requests.",
             "default": false

--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -67,6 +67,12 @@
             "description": "Crawler will ignore SSL certificate errors.",
             "default": false
         },
+        "useCookieJar": {
+            "title": "Use cookie jar",
+            "type": "boolean",
+            "description": "Crawler will use a cookie jar to persist cookies between requests.",
+            "default": false
+        },
         "maxRequestRetries": {
             "title": "Max request retries",
             "type": "integer",

--- a/cheerio-scraper/src/crawler_setup.js
+++ b/cheerio-scraper/src/crawler_setup.js
@@ -133,6 +133,9 @@ class CrawlerSetup {
                     maxEventLoopOverloadedRatio: MAX_EVENT_LOOP_OVERLOADED_RATIO,
                 },
             },
+            requestOptions: {
+                jar: this.input.useCookieJar,
+            }
         };
 
         this.crawler = new Apify.CheerioCrawler(options);


### PR DESCRIPTION
I have a site I want to scrape that uses a 301 redirect with a URL parameter to compare with a cookie to establish that cookies are enabled. I could have used the basic web-scraper but it is inefficient to fire up Puppeteer just for cookie functionality.

I've therefore made a very small change to add an option in UI to save cookies when using the Cheerio scraper. All this does is toggle the `jar` Request option on and off.

I realise that for most use cases when crawling with Cheerio people will want a completely vanilla HTTP request, but this is a simple change when cookies are required for a site.