### PR TITLE
Web scraper: small readme fix

### DIFF
--- a/web-scraper/README.md
+++ b/web-scraper/README.md
@@ -479,7 +479,7 @@ see <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/S
   for an element specified using a CSS selector to appear in the DOM
   or for a provided function to return `true`.
   This is useful for extracting data from web pages with a dynamic content,
-  where the content might be available at the time when page function is called.
+  where the content might not be available at the time when page function is called.
   
   The `options` parameter is an object with the following properties and default values:
   ```javascript


### PR DESCRIPTION
Added a missing "not" in the `waitFor` documentation in the web-scraper README.

I think it makes more sense this way, because the `waitFor` function waits for the content to become available, which means it was possibly not available originally when `pageFunction` was called, but I'm not 100% sure I'm understanding it right, so please check it out.